### PR TITLE
feat: expand go backend with node and tunnel services

### DIFF
--- a/go-backend/go.mod
+++ b/go-backend/go.mod
@@ -1,0 +1,9 @@
+module github.com/flux-panel/go-backend
+
+go 1.24.3
+
+require (
+    github.com/gin-gonic/gin v1.10.0
+    gorm.io/driver/mysql v1.5.0
+    gorm.io/gorm v1.25.5
+)

--- a/go-backend/handlers/node_handler.go
+++ b/go-backend/handlers/node_handler.go
@@ -1,0 +1,47 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/flux-panel/go-backend/models"
+	"github.com/flux-panel/go-backend/services"
+	"github.com/gin-gonic/gin"
+)
+
+// NodeHandler wraps node related HTTP handlers.
+type NodeHandler struct {
+	Service *services.NodeService
+}
+
+// NewNodeHandler creates a new NodeHandler.
+func NewNodeHandler(s *services.NodeService) *NodeHandler {
+	return &NodeHandler{Service: s}
+}
+
+// RegisterRoutes registers node routes on the engine.
+func (h *NodeHandler) RegisterRoutes(r *gin.Engine) {
+	r.POST("/nodes", h.createNode)
+	r.GET("/nodes", h.listNodes)
+}
+
+func (h *NodeHandler) createNode(c *gin.Context) {
+	var node models.Node
+	if err := c.ShouldBindJSON(&node); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if err := h.Service.CreateNode(&node); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, node)
+}
+
+func (h *NodeHandler) listNodes(c *gin.Context) {
+	nodes, err := h.Service.ListNodes()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, nodes)
+}

--- a/go-backend/handlers/tunnel_handler.go
+++ b/go-backend/handlers/tunnel_handler.go
@@ -1,0 +1,47 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/flux-panel/go-backend/models"
+	"github.com/flux-panel/go-backend/services"
+	"github.com/gin-gonic/gin"
+)
+
+// TunnelHandler wraps tunnel related HTTP handlers.
+type TunnelHandler struct {
+	Service *services.TunnelService
+}
+
+// NewTunnelHandler creates a new TunnelHandler.
+func NewTunnelHandler(s *services.TunnelService) *TunnelHandler {
+	return &TunnelHandler{Service: s}
+}
+
+// RegisterRoutes registers tunnel routes on the engine.
+func (h *TunnelHandler) RegisterRoutes(r *gin.Engine) {
+	r.POST("/tunnels", h.createTunnel)
+	r.GET("/tunnels", h.listTunnels)
+}
+
+func (h *TunnelHandler) createTunnel(c *gin.Context) {
+	var t models.Tunnel
+	if err := c.ShouldBindJSON(&t); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if err := h.Service.CreateTunnel(&t); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, t)
+}
+
+func (h *TunnelHandler) listTunnels(c *gin.Context) {
+	tunnels, err := h.Service.ListTunnels()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, tunnels)
+}

--- a/go-backend/handlers/user_handler.go
+++ b/go-backend/handlers/user_handler.go
@@ -1,0 +1,65 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/flux-panel/go-backend/models"
+	"github.com/flux-panel/go-backend/services"
+	"github.com/gin-gonic/gin"
+)
+
+// UserHandler wraps user related HTTP handlers.
+type UserHandler struct {
+	Service *services.UserService
+}
+
+// NewUserHandler creates a new UserHandler.
+func NewUserHandler(s *services.UserService) *UserHandler {
+	return &UserHandler{Service: s}
+}
+
+// RegisterRoutes registers routes on the given engine.
+func (h *UserHandler) RegisterRoutes(r *gin.Engine) {
+	r.POST("/login", h.login)
+	r.POST("/users", h.createUser)
+	r.GET("/users", h.listUsers)
+}
+
+func (h *UserHandler) login(c *gin.Context) {
+	var req struct {
+		Username string `json:"username"`
+		Password string `json:"password"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	user, err := h.Service.Login(req.Username, req.Password)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, user)
+}
+
+func (h *UserHandler) createUser(c *gin.Context) {
+	var user models.User
+	if err := c.ShouldBindJSON(&user); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if err := h.Service.CreateUser(&user); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, user)
+}
+
+func (h *UserHandler) listUsers(c *gin.Context) {
+	users, err := h.Service.ListUsers()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, users)
+}

--- a/go-backend/main.go
+++ b/go-backend/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"log"
+
+	"github.com/flux-panel/go-backend/handlers"
+	"github.com/flux-panel/go-backend/models"
+	"github.com/flux-panel/go-backend/services"
+	"github.com/gin-gonic/gin"
+)
+
+func main() {
+	dsn := "user:password@tcp(127.0.0.1:3306)/dbname?parseTime=True"
+	db, err := models.InitDB(dsn)
+	if err != nil {
+		log.Fatalf("init db: %v", err)
+	}
+
+	userService := services.NewUserService(db)
+	userHandler := handlers.NewUserHandler(userService)
+
+	nodeService := services.NewNodeService(db)
+	nodeHandler := handlers.NewNodeHandler(nodeService)
+
+	tunnelService := services.NewTunnelService(db)
+	tunnelHandler := handlers.NewTunnelHandler(tunnelService)
+
+	r := gin.Default()
+	userHandler.RegisterRoutes(r)
+	nodeHandler.RegisterRoutes(r)
+	tunnelHandler.RegisterRoutes(r)
+
+	if err := r.Run(":8080"); err != nil {
+		log.Fatalf("run server: %v", err)
+	}
+}

--- a/go-backend/models/node.go
+++ b/go-backend/models/node.go
@@ -1,0 +1,12 @@
+package models
+
+import "time"
+
+// Node represents a server node that can host tunnels.
+type Node struct {
+	ID        uint   `gorm:"primaryKey"`
+	Name      string `gorm:"size:64"`
+	Address   string `gorm:"size:255"`
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}

--- a/go-backend/models/tunnel.go
+++ b/go-backend/models/tunnel.go
@@ -1,0 +1,13 @@
+package models
+
+import "time"
+
+// Tunnel represents a proxy tunnel associated with a node.
+type Tunnel struct {
+	ID        uint   `gorm:"primaryKey"`
+	Name      string `gorm:"size:64"`
+	NodeID    uint   `gorm:"column:node_id"`
+	Config    string `gorm:"type:text"`
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}

--- a/go-backend/models/user.go
+++ b/go-backend/models/user.go
@@ -1,0 +1,31 @@
+package models
+
+import (
+	"time"
+
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+)
+
+// User represents a system user.
+type User struct {
+	ID        uint   `gorm:"primaryKey"`
+	User      string `gorm:"uniqueIndex;size:64"`
+	Password  string `gorm:"size:128"`
+	RoleID    int    `gorm:"column:role_id"`
+	Status    int    `gorm:"column:status"`
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+// InitDB initializes a gorm.DB connection using the provided DSN.
+func InitDB(dsn string) (*gorm.DB, error) {
+	db, err := gorm.Open(mysql.Open(dsn), &gorm.Config{})
+	if err != nil {
+		return nil, err
+	}
+	if err := db.AutoMigrate(&User{}, &Node{}, &Tunnel{}); err != nil {
+		return nil, err
+	}
+	return db, nil
+}

--- a/go-backend/services/node_service.go
+++ b/go-backend/services/node_service.go
@@ -1,0 +1,30 @@
+package services
+
+import (
+	"github.com/flux-panel/go-backend/models"
+	"gorm.io/gorm"
+)
+
+// NodeService contains business logic for nodes.
+type NodeService struct {
+	DB *gorm.DB
+}
+
+// NewNodeService creates a new NodeService.
+func NewNodeService(db *gorm.DB) *NodeService {
+	return &NodeService{DB: db}
+}
+
+// CreateNode inserts a new node record.
+func (s *NodeService) CreateNode(n *models.Node) error {
+	return s.DB.Create(n).Error
+}
+
+// ListNodes returns all nodes.
+func (s *NodeService) ListNodes() ([]models.Node, error) {
+	var nodes []models.Node
+	if err := s.DB.Find(&nodes).Error; err != nil {
+		return nil, err
+	}
+	return nodes, nil
+}

--- a/go-backend/services/tunnel_service.go
+++ b/go-backend/services/tunnel_service.go
@@ -1,0 +1,30 @@
+package services
+
+import (
+	"github.com/flux-panel/go-backend/models"
+	"gorm.io/gorm"
+)
+
+// TunnelService contains business logic for tunnels.
+type TunnelService struct {
+	DB *gorm.DB
+}
+
+// NewTunnelService creates a new TunnelService.
+func NewTunnelService(db *gorm.DB) *TunnelService {
+	return &TunnelService{DB: db}
+}
+
+// CreateTunnel inserts a new tunnel record.
+func (s *TunnelService) CreateTunnel(t *models.Tunnel) error {
+	return s.DB.Create(t).Error
+}
+
+// ListTunnels returns all tunnels.
+func (s *TunnelService) ListTunnels() ([]models.Tunnel, error) {
+	var tunnels []models.Tunnel
+	if err := s.DB.Find(&tunnels).Error; err != nil {
+		return nil, err
+	}
+	return tunnels, nil
+}

--- a/go-backend/services/user_service.go
+++ b/go-backend/services/user_service.go
@@ -1,0 +1,64 @@
+package services
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"errors"
+
+	"gorm.io/gorm"
+
+	"github.com/flux-panel/go-backend/models"
+)
+
+// UserService contains business logic for users.
+type UserService struct {
+	DB *gorm.DB
+}
+
+// NewUserService creates a new UserService.
+func NewUserService(db *gorm.DB) *UserService {
+	return &UserService{DB: db}
+}
+
+// hashPassword returns MD5 hash of password.
+func hashPassword(pwd string) string {
+	h := md5.Sum([]byte(pwd))
+	return hex.EncodeToString(h[:])
+}
+
+// CreateUser inserts a new user if username is unique.
+func (s *UserService) CreateUser(u *models.User) error {
+	var count int64
+	if err := s.DB.Model(&models.User{}).Where("user = ?", u.User).Count(&count).Error; err != nil {
+		return err
+	}
+	if count > 0 {
+		return errors.New("username already exists")
+	}
+	u.Password = hashPassword(u.Password)
+	return s.DB.Create(u).Error
+}
+
+// Login validates credentials and returns user.
+func (s *UserService) Login(username, password string) (*models.User, error) {
+	var user models.User
+	if err := s.DB.Where("user = ?", username).First(&user).Error; err != nil {
+		return nil, err
+	}
+	if user.Password != hashPassword(password) {
+		return nil, errors.New("invalid credentials")
+	}
+	if user.Status != 1 {
+		return nil, errors.New("account disabled")
+	}
+	return &user, nil
+}
+
+// ListUsers returns all non-admin users.
+func (s *UserService) ListUsers() ([]models.User, error) {
+	var users []models.User
+	if err := s.DB.Where("role_id <> ?", 0).Find(&users).Error; err != nil {
+		return nil, err
+	}
+	return users, nil
+}


### PR DESCRIPTION
## Summary
- add Node and Tunnel models for storing nodes and proxy tunnels
- implement Node and Tunnel services and REST handlers with Gin
- wire Node and Tunnel routes into the Go backend server

## Testing
- `go build ./...` *(fails: missing go.sum entries for gorm and gin modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b8ef3383dc832397e3899a9d70273e